### PR TITLE
Adding gruntjs with jshint target

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+
+module.exports = function (grunt) {
+  "use strict";
+
+  // Load all our grunt tasks from our package.json `devDependencies`.
+  require("load-grunt-tasks")(grunt);
+
+  grunt.initConfig({
+    "pkg": grunt.file.readJSON("package.json"),
+    "jshint": {
+      "files": [
+        "**/*.js",
+        "**/*.json",
+        "!**/node_modules/**"
+      ],
+      "options": {
+        "boss": true,
+        "maxlen": 120,
+        "newcap": false,
+        "node": true,
+        "onecase": true,
+        "smarttabs": true,
+        "strict": false,
+        "undef": true,
+        "unused": true,
+        "white": false
+      }
+    }
+  });
+
+  grunt.registerTask("default", ["jshint"]);
+};

--- a/package.json
+++ b/package.json
@@ -9,6 +9,11 @@
   "dependencies": {
     "express": "3.3.5"
   },
+    "devDependencies": {
+    "grunt": "~0.4.1",
+    "grunt-contrib-jshint": "~0.6.4",
+    "load-grunt-tasks": "~0.1.0"
+  },
   "author": "",
   "license": "BSD"
 }


### PR DESCRIPTION
Added Grunt task and some random options (taken from JSHint project package.json).
You'll need to install grunt-cli globally and then run `grunt` from command line.
